### PR TITLE
Make network component SVG size change on window resize

### DIFF
--- a/src/components/NetworkVisComponent.vue
+++ b/src/components/NetworkVisComponent.vue
@@ -17,7 +17,7 @@
         </div>
       </div>
       <div id="network-svg-container">
-        <svg id="network-svg" />
+        <svg id="network-svg" width="100%" height="100%"/>
       </div>
     </div>
   </div>
@@ -72,8 +72,6 @@ export default {
 
     this.svg = d3
       .select("#network-svg")
-      .attr("width", container.clientWidth)
-      .attr("height", container.clientHeight)
       .call(
         // eslint-disable-next-line no-unused-vars
         d3.zoom().on("zoom", (event, d) => {


### PR DESCRIPTION
I think the easiest way to make the network component size dynamic is by taking the sizing out of the `mounted` hook and just make it fill its parents components size. Vue then does the rest. 