### PR TITLE
86 refined formatting of publication scores

### DIFF
--- a/src/components/NetworkVisComponent.vue
+++ b/src/components/NetworkVisComponent.vue
@@ -252,10 +252,11 @@ export default {
       this.node
         .select("circle")
         .attr("cx", (d) => getRectSize(d) / 2 - 1)
-        .attr("cy", (d) => getRectSize(d) / 2 - 1)
+        .attr("cy", (d) => -getRectSize(d) / 2 + 1)
         .attr("r", (d) =>
           d.publication.boostFactor > 1 ? getRectSize(d) / 5 : 0
-        );
+        )
+        .attr("stroke", "black");
 
       this.link = this.link
         .data(this.graph.links, (d) => [d.source, d.target])

--- a/src/components/NetworkVisComponent.vue
+++ b/src/components/NetworkVisComponent.vue
@@ -157,6 +157,17 @@ export default {
       function getRectSize(d) {
         return RECT_SIZE * (d.publication.isActive ? ENLARGE_FACTOR : 1);
       }
+      function getBoostIndicatorSize(d) {
+        let factor = 1;
+        if (d.publication.boostFactor >= 8) {
+          factor = 2;
+        } else if (d.publication.boostFactor >= 4) {
+          factor = 1.6;
+        } else if (d.publication.boostFactor > 1) {
+          factor = 1.3;
+        }
+        return getRectSize(d) * factor;
+      }
 
       const doiToIndex = {};
       this.yearMin = 3000;
@@ -254,7 +265,7 @@ export default {
         .attr("cx", (d) => getRectSize(d) / 2 - 1)
         .attr("cy", (d) => -getRectSize(d) / 2 + 1)
         .attr("r", (d) =>
-          d.publication.boostFactor > 1 ? getRectSize(d) / 5 : 0
+          d.publication.boostFactor > 1 ? getBoostIndicatorSize(d) / 6 : 0
         )
         .attr("stroke", "black");
 

--- a/src/components/PublicationComponent.vue
+++ b/src/components/PublicationComponent.vue
@@ -20,12 +20,14 @@
           <div class="tooltip-target">
             <div class="is-size-3 is-inline-block">{{ publication.score }}</div>
             <div
-              class="boost-indicator has-background-warning is-size-6 is-inline-block ml-1"
+              class="boost-indicator has-background-warning is-size-5 is-inline-block ml-1"
               v-if="publication.boostFactor > 1"
+              :style="boostIndicatorSize"
             >
               <b-icon
               :icon="chevronType"
-              size="is-small"/>
+              size="is-small"
+              :style="chevronOffset" />
             </div>
           </div>
           <div class="reference-counts is-size-6">
@@ -216,6 +218,28 @@ export default {
       }
       return "";
     },
+
+    boostIndicatorSize: function() {
+      if (this.publication.boostFactor >= 8) {
+        return { width: "2rem", height: "2rem" };
+      } else if (this.publication.boostFactor >= 4) {
+        return { width: "1.6rem", height: "1.6rem" };
+      } else if (this.publication.boostFactor > 1) {
+        return { width: "1.3rem", height: "1.3rem "};
+      }
+      return "";
+    },
+
+    chevronOffset: function() {
+      if (this.publication.boostFactor >= 8) {
+        return { position: "relative", top: "0rem" };
+      } else if (this.publication.boostFactor >= 4) {
+        return { position: "relative", top: "-0.15rem" };
+      } else if (this.publication.boostFactor > 1) {
+        return { position: "relative", top: "-0.3rem" };
+      }
+      return "";
+    },
   },
 };
 </script>
@@ -233,12 +257,10 @@ export default {
 
 .boost-indicator {
   border-radius: 50%;
-  height: 1.5rem;
-  width: 1.5rem;
   position: absolute;
-  top: -5px;
-  right: -5px;
-  border: 1px solid black;
+  top: -7px;
+  right: -7px;
+  // vertical-align: middle;
 }
 
 li.publication-component {

--- a/src/components/PublicationComponent.vue
+++ b/src/components/PublicationComponent.vue
@@ -23,14 +23,21 @@
               class="boost-indicator has-background-warning is-size-6 is-inline-block ml-1"
               v-if="publication.boostFactor > 1"
             >
-              <b-icon :icon="chevronType" size="is-small"></b-icon>
+              <b-icon
+              :icon="chevronType"
+              size="is-small"/>
             </div>
           </div>
           <div class="is-size-7">
+            <span :style="`color: ${publication.referenceCount > 0 ? 'black' : 'grey'}`">
             {{ publication.referenceCount }}
             <b-icon icon="arrow-left-thick" size="is-small"></b-icon>
-            + {{ publication.citationCount }}
+            </span>
+            +
+            <span :style="`color: ${publication.citationCount > 0 ? 'black' : 'grey'}`">
+              {{ publication.citationCount }}
             <b-icon icon="arrow-right-thick" size="is-small"></b-icon>
+            </span>
           </div>
         </template>
         <div>

--- a/src/components/PublicationComponent.vue
+++ b/src/components/PublicationComponent.vue
@@ -29,13 +29,13 @@
             </div>
           </div>
           <div class="reference-counts is-size-6">
-            <div style="float: left">
+            <div class="is-pulled-left">
               <span v-if="publication.referenceCount > 0">
                 {{ publication.referenceCount }}
                 <b-icon icon="arrow-left-thick" size="is-small"></b-icon>
               </span>
             </div>
-            <div style="float: right">
+            <div class="is-pulled-right">
               <span v-if="publication.citationCount > 0">
               <b-icon icon="arrow-right-thick" size="is-small"></b-icon>
                 {{ publication.citationCount }}

--- a/src/components/PublicationComponent.vue
+++ b/src/components/PublicationComponent.vue
@@ -20,7 +20,7 @@
           <div class="tooltip-target">
             <div class="is-size-3 is-inline-block">{{ publication.score }}</div>
             <div
-              class="has-background-warning is-size-6 is-inline-block ml-1"
+              class="boost-indicator has-background-warning is-size-6 is-inline-block ml-1"
               v-if="publication.boostFactor > 1"
             >
               <b-icon :icon="chevronType" size="is-small"></b-icon>
@@ -212,6 +212,14 @@ export default {
 
 <style lang="scss" scoped>
 @import "~bulma/sass/utilities/_all";
+
+.boost-indicator {
+  border-radius: 50%;
+  height: 25px;
+  width: 25px;
+  position: relative;
+  top: -5px;
+}
 
 li.publication-component {
   padding: 0;

--- a/src/components/PublicationComponent.vue
+++ b/src/components/PublicationComponent.vue
@@ -28,16 +28,19 @@
               size="is-small"/>
             </div>
           </div>
-          <div class="is-size-7">
-            <span :style="`color: ${publication.referenceCount > 0 ? 'black' : 'grey'}`">
-            {{ publication.referenceCount }}
-            <b-icon icon="arrow-left-thick" size="is-small"></b-icon>
-            </span>
-            +
-            <span :style="`color: ${publication.citationCount > 0 ? 'black' : 'grey'}`">
-              {{ publication.citationCount }}
-            <b-icon icon="arrow-right-thick" size="is-small"></b-icon>
-            </span>
+          <div class="is-size-6">
+            <div class="reference-count" style="float: left">
+              <span v-if="publication.referenceCount > 0">
+                {{ publication.referenceCount }}
+                <b-icon icon="arrow-left-thick" size="is-small"></b-icon>
+              </span>
+            </div>
+            <div class="reference-count" style="float: right">
+              <span v-if="publication.citationCount > 0">
+              <b-icon icon="arrow-right-thick" size="is-small"></b-icon>
+                {{ publication.citationCount }}
+              </span>
+            </div>
           </div>
         </template>
         <div>
@@ -220,12 +223,22 @@ export default {
 <style lang="scss" scoped>
 @import "~bulma/sass/utilities/_all";
 
+.tooltip-target {
+  position: relative;
+}
+
+.reference-count {
+  width: 50%;
+}
+
 .boost-indicator {
   border-radius: 50%;
   height: 1.5rem;
   width: 1.5rem;
-  position: relative;
+  position: absolute;
   top: -5px;
+  right: -5px;
+  border: 1px solid black;
 }
 
 li.publication-component {

--- a/src/components/PublicationComponent.vue
+++ b/src/components/PublicationComponent.vue
@@ -222,8 +222,8 @@ export default {
 
 .boost-indicator {
   border-radius: 50%;
-  height: 25px;
-  width: 25px;
+  height: 1.5rem;
+  width: 1.5rem;
   position: relative;
   top: -5px;
 }

--- a/src/components/PublicationComponent.vue
+++ b/src/components/PublicationComponent.vue
@@ -28,14 +28,14 @@
               size="is-small"/>
             </div>
           </div>
-          <div class="is-size-6">
-            <div class="reference-count" style="float: left">
+          <div class="reference-counts is-size-6">
+            <div style="float: left">
               <span v-if="publication.referenceCount > 0">
                 {{ publication.referenceCount }}
                 <b-icon icon="arrow-left-thick" size="is-small"></b-icon>
               </span>
             </div>
-            <div class="reference-count" style="float: right">
+            <div style="float: right">
               <span v-if="publication.citationCount > 0">
               <b-icon icon="arrow-right-thick" size="is-small"></b-icon>
                 {{ publication.citationCount }}
@@ -227,7 +227,7 @@ export default {
   position: relative;
 }
 
-.reference-count {
+.reference-counts > div {
   width: 50%;
 }
 


### PR DESCRIPTION
[DRAFT]

Chevrons now have a round background like the circles in the network visualization. 
Citation and reference counts (and the arrow icons) are greyed out if the value is 0.