### PR TITLE
Prevent boost indicator from overlapping text in network vis

### DIFF
--- a/src/components/NetworkVisComponent.vue
+++ b/src/components/NetworkVisComponent.vue
@@ -166,7 +166,7 @@ export default {
         } else if (d.publication.boostFactor > 1) {
           factor = 1.3;
         }
-        return getRectSize(d) * factor;
+        return getRectSize(d) * factor * 0.8;
       }
 
       const doiToIndex = {};
@@ -258,6 +258,7 @@ export default {
       this.node
         .select("text")
         .attr("y", 1)
+        .attr("font-size", "0.8em")
         .text((d) => d.publication.score);
 
       this.node


### PR DESCRIPTION
Boost indicator in network vis slightly smaller.
Font in network vis slightly smaller.

current look: 
![grafik](https://user-images.githubusercontent.com/44530236/159509097-05b056dd-fd6e-4ab1-b47b-e89ab6c28ff1.png)
![grafik](https://user-images.githubusercontent.com/44530236/159509191-3e3016f9-27bf-4c0a-8415-9cd7fa7b56b7.png)

Close up I think it looks good. Just not sure if it is maybe too small when zooming out now.