### PR TITLE
Only process the activate event if the same publication was not already activated.

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -248,8 +248,10 @@ export default {
     },
 
     activatePublicationComponentByDoi: function (doi) {
-      this.activatePublicationComponent(document.getElementById(doi));
-      this.setActivePublication(doi);
+      if (doi !== this.activePublication?.doi) {
+        this.activatePublicationComponent(document.getElementById(doi));
+        this.setActivePublication(doi);
+      }
     },
 
     exportSession: function () {


### PR DESCRIPTION
This keeps the double emission of the activate events, but at least it is not processed twice.