### PR TITLE
Fix: converting all DOIs to lower case

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -149,6 +149,7 @@ export default {
       let addedPublicationsCount = 0;
       let addedDoi = "";
       dois.forEach((doi) => {
+        doi = doi.toLowerCase();
         if (this.excludedPublicationsDois.has(doi)) {
           this.excludedPublicationsDois.delete(doi);
         }
@@ -302,6 +303,7 @@ export default {
     },
 
     activatePublicationComponentByDoi: function (doi) {
+      console.log(publications[doi])
       if (doi !== this.activePublication?.doi) {
         this.activatePublicationComponent(document.getElementById(doi));
         this.setActivePublication(doi);

--- a/src/Publication.js
+++ b/src/Publication.js
@@ -6,7 +6,7 @@ import { shuffle } from "./Util.js"
 export default class Publication {
     constructor(doi) {
         // identifier
-        this.doi = doi;
+        this.doi = doi.toLowerCase();
         this.doiUrl = "https://doi.org/" + doi;
         // meta-data
         this.title = "";
@@ -107,12 +107,12 @@ export default class Publication {
                     // references and citations
                     data.reference.split("; ").forEach(referenceDoi => {
                         if (referenceDoi) {
-                            this.referenceDois.push(referenceDoi);
+                            this.referenceDois.push(referenceDoi.toLowerCase());
                         }
                     });
                     data.citation.split("; ").forEach(citationDoi => {
                         if (citationDoi) {
-                            this.citationDois.push(citationDoi);
+                            this.citationDois.push(citationDoi.toLowerCase());
                         }
                     });
                     this.citationsPerYear = this.citationDois.length / (Math.max(1, CURRENT_YEAR - this.year));
@@ -234,6 +234,7 @@ export default class Publication {
     }
 
     static async computeSuggestions(publications, excludedPublicationsDois, boostKeywords, updateLoadingToast, maxSuggestions) {
+
         function incrementSuggestedPublicationCounter(
             doi,
             counter,


### PR DESCRIPTION
As not being consistent in the data, missed matches can be avoided through that.