### PR TITLE
Add MIME type to file download

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -385,7 +385,7 @@ export default {
         excluded: Array.from(this.excludedPublicationsDois),
         boost: this.boostKeywords.join(", "),
       };
-      saveAsFile("session.json", JSON.stringify(data));
+      saveAsFile("session.json", "application/json", JSON.stringify(data));
     },
 
     importSession: function (file) {
@@ -415,7 +415,7 @@ export default {
       publicationList.forEach(
         (publication) => (bib += publication.toBibtex() + "\n\n")
       );
-      saveAsFile("publications.bib", bib);
+      saveAsFile("publications.bib", "application/x-bibtex", bib);
     },
 
     clearSession: function () {

--- a/src/Util.js
+++ b/src/Util.js
@@ -1,6 +1,6 @@
 // https://stackoverflow.com/questions/3665115/how-to-create-a-file-in-memory-for-user-to-download-but-not-through-server?answertab=active#tab-top
-export function saveAsFile(filename, data) {
-  const blob = new Blob([data], { type: "text/csv" });
+export function saveAsFile(filename, mime, data) {
+  const blob = new Blob([data], { type: mime });
   if (window.navigator.msSaveOrOpenBlob) {
     window.navigator.msSaveBlob(blob, filename);
   } else {


### PR DESCRIPTION
When downloading the session as json or the selected publications as bibtex, Mobile Safari downloads it as a csv file.
Tested on iOS 15.5

Fix: set mime type according.
Offending line: https://github.com/fabian-beck/pure-suggest/blob/702ba2ffbd0514ec527fe4b5c6070cf05ccad0f0/src/Util.js#L3