### PR TITLE
Arrange publication tags horizontally before stacking

### DIFF
--- a/src/components/PublicationDescription.vue
+++ b/src/components/PublicationDescription.vue
@@ -417,12 +417,13 @@ div.summary {
 .publication-tags {
   display: flex;
   flex: 0 1 auto;
-  flex-direction: column;
-  align-items: flex-end;
+  flex-flow: row wrap;
+  justify-content: flex-end;
+  align-items: flex-start;
   gap: 0.25rem;
   margin-top: 0.1rem;
   margin-left: auto;
-  min-width: 0;
+  max-width: 30%;
 }
 
 .publication-tags :deep(.v-chip) {


### PR DESCRIPTION
Fixes #647

Publication tags previously always stacked vertically. They now flow horizontally within up to 30% of the summary box width and wrap onto new rows only when there is not enough horizontal space.

### Change
- `.publication-tags` switched from `flex-direction: column` to `flex-flow: row wrap` with `max-width: 30%`, keeping right alignment via `justify-content: flex-end`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DL8Qa4QmmB4Cx2Yk9y8WEX)_